### PR TITLE
Allow a custom header name to be passed in options

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,11 +6,12 @@ module.exports = function (options) {
     options = options || {};
     options.uuidVersion = options.uuidVersion || 'v4';
     options.setHeader = options.setHeader === undefined || !!options.setHeader;
+    options.headerName = options.headerName || 'X-Request-Id';
 
     return function (req, res, next) {
-        req.id = req.headers['x-request-id'] || uuid[options.uuidVersion](options, options.buffer, options.offset);
+        req.id = req.header(options.headerName) || uuid[options.uuidVersion](options, options.buffer, options.offset);
         if (options.setHeader) {
-            res.setHeader('X-Request-Id', req.id);
+            res.setHeader(options.headerName, req.id);
         }
         next();
     };

--- a/readme.md
+++ b/readme.md
@@ -32,6 +32,7 @@ Returns middleware function, that appends request id to req object.
 
  * `uuidVersion` - version of uuid to use (defaults to `v4`). Can be one of methods from [node-uuid](https://github.com/broofa/node-uuid).
  * `setHeader` - boolean, indicates that header should be added to response (defaults to `true`).
+ * `headerName` - string, indicates the header name to use (defaults to `X-Request-Id`).
 
 This options fields are passed to node-uuid functions directly:
 

--- a/test/index.js
+++ b/test/index.js
@@ -74,6 +74,17 @@ describe('express-request-id', function () {
             });
     });
 
+    it('should use the `X-Custom-Id` header name with option headerName=X-Custom-Id', function (done) {
+        var app = require('express')();
+        app.use(requestId({ headerName: 'X-Custom-Id' }));
+        app.get('/', noop);
+
+        request(app)
+            .get('/')
+            .expect('X-Custom-Id', /\w{8}-\w{4}-4\w{3}-\w{4}-\w{12}/)
+            .end(done);
+    });
+
     it('should use uuid v4 by default', function (done) {
         var app = require('express')();
         app.use(requestId());


### PR DESCRIPTION
This simply allows custom headers other than `X-Request-Id` to be used.  `X-Request-Id` is the standard header name for correlation, however certain organizations do not follow this convention.

Notes:
- Prefer `req.header(headerName)` over `req.headers[headerName]` for [built in case-insensitivity](https://expressjs.com/en/api.html#req.get).