### PR TITLE
Make the id attribute name configurable

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,11 +7,12 @@ module.exports = function (options) {
     options.uuidVersion = options.uuidVersion || 'v4';
     options.setHeader = options.setHeader === undefined || !!options.setHeader;
     options.headerName = options.headerName || 'X-Request-Id';
+    options.attributeName = options.attributeName || 'id';
 
     return function (req, res, next) {
-        req.id = req.header(options.headerName) || uuid[options.uuidVersion](options, options.buffer, options.offset);
+        req[options.attributeName] = req.header(options.headerName) || uuid[options.uuidVersion](options, options.buffer, options.offset);
         if (options.setHeader) {
-            res.setHeader(options.headerName, req.id);
+            res.setHeader(options.headerName, req[options.attributeName]);
         }
         next();
     };

--- a/readme.md
+++ b/readme.md
@@ -33,6 +33,7 @@ Returns middleware function, that appends request id to req object.
  * `uuidVersion` - version of uuid to use (defaults to `v4`). Can be one of methods from [node-uuid](https://github.com/broofa/node-uuid).
  * `setHeader` - boolean, indicates that header should be added to response (defaults to `true`).
  * `headerName` - string, indicates the header name to use (defaults to `X-Request-Id`).
+ * `attributeName` - string, indicates the attribute name used for the identifier on the request object (defaults to `id`)
 
 This options fields are passed to node-uuid functions directly:
 

--- a/test/index.js
+++ b/test/index.js
@@ -117,7 +117,7 @@ describe('express-request-id', function () {
             .expect('X-Request-Id', /00000000-0000-1000-8000-000000000000/)
             .end(done);
     });
-    it('should set request id', function (done) {
+    it('should set use the specified attribute name for the identifier', function (done) {
         var app = require('express')();
         app.use(requestId({ attributeName: 'specificId' }));
         app.get('/', function (req, res, next) {

--- a/test/index.js
+++ b/test/index.js
@@ -117,4 +117,16 @@ describe('express-request-id', function () {
             .expect('X-Request-Id', /00000000-0000-1000-8000-000000000000/)
             .end(done);
     });
+    it('should set request id', function (done) {
+        var app = require('express')();
+        app.use(requestId({ attributeName: 'specificId' }));
+        app.get('/', function (req, res, next) {
+            should.exist(req);
+            req.should.have.property('specificId').with.lengthOf(36);
+            req.should.not.have.property('id');
+            next();
+        });
+
+        request(app).get('/').end(done);
+    });
 });


### PR DESCRIPTION
I'm working on a project where the id attribute for https requests is mandated as something other than `id` across various services (specifically a "conversation" id, distinct from other things such as operation /context ids) and this change allows for such use.