### PR TITLE
Add an option to specify a 'prefix' to the UUID value.

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,9 +8,10 @@ module.exports = function (options) {
     options.setHeader = options.setHeader === undefined || !!options.setHeader;
     options.headerName = options.headerName || 'X-Request-Id';
     options.attributeName = options.attributeName || 'id';
+    options.prefix = options.prefix || '';
 
     return function (req, res, next) {
-        req[options.attributeName] = req.header(options.headerName) || uuid[options.uuidVersion](options, options.buffer, options.offset);
+        req[options.attributeName] = req.header(options.headerName) || options.prefix+uuid[options.uuidVersion](options, options.buffer, options.offset);
         if (options.setHeader) {
             res.setHeader(options.headerName, req[options.attributeName]);
         }

--- a/readme.md
+++ b/readme.md
@@ -34,6 +34,7 @@ Returns middleware function, that appends request id to req object.
  * `setHeader` - boolean, indicates that header should be added to response (defaults to `true`).
  * `headerName` - string, indicates the header name to use (defaults to `X-Request-Id`).
  * `attributeName` - string, indicates the attribute name used for the identifier on the request object (defaults to `id`)
+ * `prefix` - string, provides a prefix to be prepended to the uuid to clarify initial entry point in a request chain
 
 This options fields are passed to node-uuid functions directly:
 

--- a/test/index.js
+++ b/test/index.js
@@ -117,6 +117,7 @@ describe('express-request-id', function () {
             .expect('X-Request-Id', /00000000-0000-1000-8000-000000000000/)
             .end(done);
     });
+    
     it('should set use the specified attribute name for the identifier', function (done) {
         var app = require('express')();
         app.use(requestId({ attributeName: 'specificId' }));
@@ -128,5 +129,30 @@ describe('express-request-id', function () {
         });
 
         request(app).get('/').end(done);
+    });
+
+    it('should add a specified prefix to the request id', function (done) {
+        var app = require('express')();
+        app.use(requestId({ prefix : 'myapp-' }));
+        app.get('/', function (req, res, next) {
+            should.exist(req);
+            req.should.have.property('id').startWith('myapp-');
+            req.should.have.property('id').with.lengthOf(42);
+            next();
+        });
+
+        request(app).get('/').end(done);
+    });
+
+    it('should not add prefix when the `X-Request-Id` header value was provided', function (done) {
+        var app = require('express')();
+        app.use(requestId({ prefix : 'myapp-' }));
+        app.get('/', function (req, res, next) {
+            should.exist(req);
+            req.should.have.property('id').equal('ARTIFICIAL-ID');
+            next();
+        });
+
+        request(app).get('/').set('X-Request-Id', 'ARTIFICIAL-ID').end(done);
     });
 });


### PR DESCRIPTION
The inclusion of a custom prefix to the UUID value allows the source of the initial request to be identified when the header is passed along a chain of services, which helps in tracking down issues through log entries.