### PR TITLE
Use Node pure req.headers (added support Koa)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 sudo: false
 language: node_js
 node_js:
-  - "0.10"
-  - "0.12"
-  - "iojs"
-
+  - 6
+  - 8
+  - 10

--- a/index.js
+++ b/index.js
@@ -10,7 +10,7 @@ module.exports = function (options) {
     options.attributeName = options.attributeName || 'id';
 
     return function (req, res, next) {
-        req[options.attributeName] = req.header(options.headerName) || uuid[options.uuidVersion](options, options.buffer, options.offset);
+        req[options.attributeName] = req.headers[options.headerName.toLowerCase()] || uuid[options.uuidVersion](options, options.buffer, options.offset);
         if (options.setHeader) {
             res.setHeader(options.headerName, req[options.attributeName]);
         }

--- a/package.json
+++ b/package.json
@@ -24,12 +24,12 @@
   },
   "homepage": "https://github.com/floatdrop/express-request-id",
   "devDependencies": {
-    "express": "~4.4.5",
-    "mocha": "~1.20.1",
-    "should": "~4.0.4",
-    "supertest": "~0.13.0"
+    "express": "~4.16.3",
+    "mocha": "~5.2.0",
+    "should": "~13.2.3",
+    "supertest": "~3.3.0"
   },
   "dependencies": {
-    "uuid": "^3.0.1"
+    "uuid": "^3.3.2"
   }
 }


### PR DESCRIPTION
I tried using this package in combination with [koa-connect](https://github.com/vkurchatkin/koa-connect) but it was erroring since `req.header` is not a function in Koa.  Simply changing this to use the native approach that both Koa and Express do was the fix.

Ref:
https://github.com/koajs/koa/blob/master/lib/request.js#L675-L684
https://github.com/expressjs/express/blob/master/lib/request.js#L74-L84