### PR TITLE
Fix TypeScript error caused by duplicate Request identifiers

### DIFF
--- a/types.d.ts
+++ b/types.d.ts
@@ -4,9 +4,11 @@ import type {Request, RequestHandler} from 'express-serve-static-core';
 declare global {
 	namespace Express {
 		// Inject additional properties on express.Request
-		type Request = {
+		// Should be interface to support declaration merging.
+		// eslint-disable-next-line @typescript-eslint/consistent-type-definitions
+		interface Request {
 			id: string;
-		};
+		}
 	}
 }
 


### PR DESCRIPTION
Only `interface` declarations can be merged and using `type` results in the below error.

```
node_modules/@types/express-serve-static-core/index.d.ts:19:19 - error TS2300: Duplicate identifier 'Request'.

19         interface Request {}
                     ~~~~~~~

  node_modules/express-request-id/types.d.ts:7:8
    7   type Request = {
             ~~~~~~~
    'Request' was also declared here.

node_modules/express-request-id/types.d.ts:7:8 - error TS2300: Duplicate identifier 'Request'.

7   type Request = {
         ~~~~~~~

  node_modules/@types/express-serve-static-core/index.d.ts:19:19
    19         interface Request {}
                         ~~~~~~~
    'Request' was also declared here.
```

See https://www.typescriptlang.org/docs/handbook/2/everyday-types.html#differences-between-type-aliases-and-interfaces